### PR TITLE
Add OWNERS from k8s.io/kubernetes/federation

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - colhom
+  - csbell
+  - irfanurrehman
+  - madhusudancs
+  - marun
+  - mwielgus
+  - nikhiljindal
+  - quinton-hoole
+  - shashidharatd
+approvers:
+  - csbell
+  - irfanurrehman
+  - madhusudancs
+  - mwielgus
+  - nikhiljindal
+  - quinton-hoole


### PR DESCRIPTION
This is required to enable the submit queue.