### PR TITLE
Enable running e2e tests on federation from k/f repo

### DIFF
--- a/cluster/get-federation-binaries.sh
+++ b/cluster/get-federation-binaries.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script downloads and installs the Federation client and server
+# (and optionally test) binaries,
+# It is intended to be called from an extracted Federation release tarball.
+#
+# We automatically choose the correct client binaries to download.
+#
+# Options:
+#  Set FEDERATION_SERVER_ARCH to choose the server
+#  architecture to download:
+#    * amd64 [default]
+#    * arm
+#    * arm64
+#    * ppc64le
+#    * s390x
+#
+#  Set FEDERATION_SKIP_CONFIRM to skip the installation confirmation prompt.
+#  Set FEDERATION_RELEASE_URL to choose where to download binaries from.
+#    (Defaults to https://storage.googleapis.com/kubernetes-federation-release/release).
+#  Set FEDERATION_DOWNLOAD_TESTS to additionally download and extract the test
+#    binaries tarball.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
+
+FEDERATION_RELEASE_URL="${FEDERATION_RELEASE_URL:-https://storage.googleapis.com/kubernetes-federation-release}"
+
+function detect_federation_release() {
+  if [[ -n "${FEDERATION_VERSION:-}" ]]; then
+    return 0  # Allow caller to explicitly set version
+  fi
+
+  if [[ ! -e "${KUBE_ROOT}/version" ]]; then
+    echo "Can't determine Federation release." >&2
+    echo "${BASH_SOURCE} should only be run from a prebuilt Federation release." >&2
+    echo "Did you mean to use get-federation.sh instead?" >&2
+    exit 1
+  fi
+
+  FEDERATION_VERSION=$(cat "${KUBE_ROOT}/version")
+}
+
+function detect_client_info() {
+  local kernel=$(uname -s)
+  case "${kernel}" in
+    Darwin)
+      CLIENT_PLATFORM="darwin"
+      ;;
+    Linux)
+      CLIENT_PLATFORM="linux"
+      ;;
+    *)
+      echo "Unknown, unsupported platform: ${kernel}." >&2
+      echo "Supported platforms: Linux, Darwin." >&2
+      echo "Bailing out." >&2
+      exit 2
+  esac
+
+  # TODO: migrate the kube::util::host_platform function out of hack/lib and
+  # use it here.
+  local machine=$(uname -m)
+  case "${machine}" in
+    x86_64*|i?86_64*|amd64*)
+      CLIENT_ARCH="amd64"
+      ;;
+    aarch64*|arm64*)
+      CLIENT_ARCH="arm64"
+      ;;
+    arm*)
+      CLIENT_ARCH="arm"
+      ;;
+    i?86*)
+      CLIENT_ARCH="386"
+      ;;
+    s390x*)
+      CLIENT_ARCH="s390x"
+      ;;
+    *)
+      echo "Unknown, unsupported architecture (${machine})." >&2
+      echo "Supported architectures x86_64, i686, arm, arm64, s390x." >&2
+      echo "Bailing out." >&2
+      exit 3
+      ;;
+  esac
+}
+
+function md5sum_file() {
+  if which md5 >/dev/null 2>&1; then
+    md5 -q "$1"
+  else
+    md5sum "$1" | awk '{ print $1 }'
+  fi
+}
+
+function sha1sum_file() {
+  if which sha1sum >/dev/null 2>&1; then
+    sha1sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a1 "$1" | awk '{ print $1 }'
+  fi
+}
+
+function download_tarball() {
+  local -r download_path="$1"
+  local -r file="$2"
+  url="${DOWNLOAD_URL_PREFIX}/${file}"
+  mkdir -p "${download_path}"
+  if [[ $(which curl) ]]; then
+    curl -fL --retry 3 --keepalive-time 2 "${url}" -o "${download_path}/${file}"
+  elif [[ $(which wget) ]]; then
+    wget "${url}" -O "${download_path}/${file}"
+  else
+    echo "Couldn't find curl or wget.  Bailing out." >&2
+    exit 4
+  fi
+  echo
+  local md5sum=$(md5sum_file "${download_path}/${file}")
+  echo "md5sum(${file})=${md5sum}"
+  local sha1sum=$(sha1sum_file "${download_path}/${file}")
+  echo "sha1sum(${file})=${sha1sum}"
+  echo
+  # TODO: add actual verification
+}
+
+function extract_arch_tarball() {
+  local -r tarfile="$1"
+  local -r platform="$2"
+  local -r arch="$3"
+
+  platforms_dir="${KUBE_ROOT}/platforms/${platform}/${arch}"
+  echo "Extracting ${tarfile} into ${platforms_dir}"
+  mkdir -p "${platforms_dir}"
+  # Tarball looks like federation/{client,server}/bin/BINARY"
+  tar -xzf "${tarfile}" --strip-components 3 -C "${platforms_dir}"
+  # Create convenience symlink
+  ln -sf "${platforms_dir}" "$(dirname ${tarfile})/bin"
+  echo "Add '$(dirname ${tarfile})/bin' to your PATH to use newly-installed binaries."
+}
+
+detect_federation_release
+DOWNLOAD_URL_PREFIX="${FEDERATION_RELEASE_URL}/${FEDERATION_VERSION}"
+
+SERVER_PLATFORM="linux"
+SERVER_ARCH="${FEDERATION_SERVER_ARCH:-amd64}"
+SERVER_TAR="federation-server-${SERVER_PLATFORM}-${SERVER_ARCH}.tar.gz"
+
+detect_client_info
+CLIENT_TAR="federation-client-${CLIENT_PLATFORM}-${CLIENT_ARCH}.tar.gz"
+
+echo "Federation release: ${FEDERATION_VERSION}"
+echo "Server: ${SERVER_PLATFORM}/${SERVER_ARCH}  (to override, set FEDERATION_SERVER_ARCH)"
+echo "Client: ${CLIENT_PLATFORM}/${CLIENT_ARCH}  (autodetected)"
+echo
+
+echo "Will download ${SERVER_TAR} from ${DOWNLOAD_URL_PREFIX}"
+echo "Will download and extract ${CLIENT_TAR} from ${DOWNLOAD_URL_PREFIX}"
+
+TESTS_TAR="federation-test.tar.gz"
+DOWNLOAD_TESTS_TAR=false
+if [[ -n "${FEDERATION_DOWNLOAD_TESTS-}" ]]; then
+  DOWNLOAD_TESTS_TAR=true
+  echo "Will download and extract ${TESTS_TAR} from ${DOWNLOAD_URL_PREFIX}"
+fi
+
+if [[ -z "${FEDERATION_SKIP_CONFIRM-}" ]]; then
+  echo "Is this ok? [Y]/n"
+  read confirm
+  if [[ "${confirm}" =~ ^[nN]$ ]]; then
+    echo "Aborting."
+    exit 1
+  fi
+fi
+
+download_tarball "${KUBE_ROOT}/server" "${SERVER_TAR}"
+
+download_tarball "${KUBE_ROOT}/client" "${CLIENT_TAR}"
+extract_arch_tarball "${KUBE_ROOT}/client/${CLIENT_TAR}" "${CLIENT_PLATFORM}" "${CLIENT_ARCH}"
+
+if "${DOWNLOAD_TESTS_TAR}"; then
+  download_tarball "${KUBE_ROOT}/test" "${TESTS_TAR}"
+  echo "Extracting ${TESTS_TAR} into ${KUBE_ROOT}"
+  # Strip leading "federation/"
+  tar -xzf "${KUBE_ROOT}/test/${TESTS_TAR}" --strip-components 1 -C "${KUBE_ROOT}"
+fi

--- a/cluster/get-federation.sh
+++ b/cluster/get-federation.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Download a Federation release.
+# Usage:
+#   wget -q -O - https://storage.googleapis.com/kubernetes-federation-release | bash
+# or
+#   curl -fsSL https://storage.googleapis.com/kubernetes-federation-release | bash
+#
+# Advanced options
+#  Set FEDERATION_RELEASE to choose a specific release instead of the current
+#    stable release, (e.g. 'v1.3.7').
+#    See https://github.com/kubernetes/federation/releases for release options.
+#  Set FEDERATION_RELEASE_URL to choose where to download binaries from.
+#    (Defaults to https://storage.googleapis.com/kubernetes-federation-release/release).
+#
+#  Set FEDERATION_SKIP_CONFIRM to skip the installation confirmation prompt.
+#  Set FEDERATION_SKIP_RELEASE_VALIDATION to skip trying to validate the
+#      federation release string. This implies that you know what you're doing
+#      and have set FEDERATION_RELEASE and FEDERATION_RELEASE_URL properly.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# If FEDERATION_RELEASE_URL is overridden but FEDERATION_CI_RELEASE_URL is not then set FEDERATION_CI_RELEASE_URL to FEDERATION_RELEASE_URL.
+FEDERATION_CI_RELEASE_URL="${FEDERATION_CI_RELEASE_URL:-${FEDERATION_RELEASE_URL:-https://storage.googleapis.com/kubernetes-federation-release/ci}}"
+FEDERATION_RELEASE_URL="${FEDERATION_RELEASE_URL:-https://storage.googleapis.com/kubernetes-federation-release}"
+
+FEDERATION_RELEASE_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-([a-zA-Z0-9]+)\\.(0|[1-9][0-9]*))?$"
+FEDERATION_CI_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-([a-zA-Z0-9]+)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)\\+[-0-9a-z]*)?$"
+
+# Sets FEDERATION_VERSION variable if an explicit version number was provided (e.g. "v1.0.6",
+# "v1.2.0-alpha.1.881+376438b69c7612") or resolves the "published" version
+# <path>/<version> (e.g. "release/stable",' "ci/latest-1") by reading from GCS.
+#
+# See the docs on getting builds for more information about version
+# publication.
+#
+# Args:
+#   $1 version string from command line
+# Vars set:
+#   FEDERATION_VERSION
+function set_binary_version() {
+  if [[ "${1}" =~ "/" ]]; then
+    export FEDERATION_VERSION=$(curl -fsSL --retry 5 "https://storage.googleapis.com/kubernetes-federation-release/${1}.txt")
+  else
+    export FEDERATION_VERSION=${1}
+  fi
+}
+
+# Use the script from inside the Federation tarball to fetch the client and
+# server binaries (if not included in federation.tar.gz).
+function download_federation_binaries {
+  (
+    cd federation
+    if [[ -x ./cluster/get-federation-binaries.sh ]]; then
+      # Make sure to use the same download URL in get-federation-binaries.sh
+      FEDERATION_RELEASE_URL="${FEDERATION_RELEASE_URL}" \
+        ./cluster/get-federation-binaries.sh
+    fi
+  )
+}
+
+file=federation.tar.gz
+release=${FEDERATION_RELEASE:-"release/stable"}
+
+# Validate Federation release version.
+# Translate a published version <bucket>/<version> (e.g. "release/stable") to version number.
+set_binary_version "${release}"
+if [[ -z "${FEDERATION_SKIP_RELEASE_VALIDATION-}" ]]; then
+  if [[ ${FEDERATION_VERSION} =~ ${FEDERATION_CI_VERSION_REGEX} ]]; then
+    # Override FEDERATION_RELEASE_URL to point to the CI bucket;
+    # this will be used by get-federation-binaries.sh.
+    FEDERATION_RELEASE_URL="${FEDERATION_CI_RELEASE_URL}"
+  elif ! [[ ${FEDERATION_VERSION} =~ ${FEDERATION_RELEASE_VERSION_REGEX} ]]; then
+    echo "Version doesn't match regexp" >&2
+    exit 1
+  fi
+fi
+federation_tar_url="${FEDERATION_RELEASE_URL}/${FEDERATION_VERSION}/${file}"
+
+need_download=true
+if [[ -r "${PWD}/${file}" ]]; then
+  downloaded_version=$(tar -xzOf "${PWD}/${file}" federation/version 2>/dev/null || true)
+  echo "Found preexisting ${file}, release ${downloaded_version}"
+  if [[ "${downloaded_version}" == "${FEDERATION_VERSION}" ]]; then
+    echo "Using preexisting federation.tar.gz"
+    need_download=false
+  fi
+fi
+
+if "${need_download}"; then
+  echo "Downloading federation release ${FEDERATION_VERSION}"
+  echo "  from ${federation_tar_url}"
+  echo "  to ${PWD}/${file}"
+fi
+
+if [[ -e "${PWD}/federation" ]]; then
+  # Let's try not to accidentally nuke something that isn't a federation
+  # release dir.
+  if [[ ! -f "${PWD}/federation/version" ]]; then
+    echo "${PWD}/federation exists but does not look like a Federation release."
+    echo "Aborting!"
+    exit 5
+  fi
+  echo "Will also delete preexisting 'federation' directory."
+fi
+
+if [[ -z "${FEDERATION_SKIP_CONFIRM-}" ]]; then
+  echo "Is this ok? [Y]/n"
+  read confirm
+  if [[ "${confirm}" =~ ^[nN]$ ]]; then
+    echo "Aborting."
+    exit 0
+  fi
+fi
+
+if "${need_download}"; then
+  if [[ $(which curl) ]]; then
+    curl -fL --retry 5 --keepalive-time 2 "${federation_tar_url}" -o "${file}"
+  elif [[ $(which wget) ]]; then
+    wget "${federation_tar_url}"
+  else
+    echo "Couldn't find curl or wget.  Bailing out."
+    exit 1
+  fi
+fi
+
+echo "Unpacking federation release ${FEDERATION_VERSION}"
+rm -rf "${PWD}/federation"
+tar -xzf ${file}
+
+download_federation_binaries

--- a/test/cluster/federation-up.sh
+++ b/test/cluster/federation-up.sh
@@ -43,16 +43,16 @@ DNS_PROVIDER="${FEDERATION_DNS_PROVIDER:-google-clouddns}"
 # These functions should be consolidated to read the version from
 # kubernetes version defs file.
 function get_version() {
-  local -r versions_file="${KUBE_ROOT}/_output/federation/versions"
+  local -r versions_file="${KUBE_ROOT}/version"
 
-  if [[ -n "${KUBERNETES_RELEASE:-}" ]]; then
-    echo "${KUBERNETES_RELEASE//+/_}"
+  if [[ -n "${FEDERATION_RELEASE:-}" ]]; then
+    echo "${FEDERATION_RELEASE//+/_}"
     return
   fi
 
   if [[ ! -f "${versions_file}" ]]; then
     echo "Couldn't determine the release version: neither the " \
-     "KUBERNETES_RELEASE environment variable is set, nor does " \
+     "FEDERATION_RELEASE environment variable is set, nor does " \
      "the versions file exist at ${versions_file}"
     exit 1
   fi

--- a/test/cluster/federation-up.sh
+++ b/test/cluster/federation-up.sh
@@ -134,5 +134,21 @@ function join_clusters() {
   done
 }
 
+function push_to_registry() {
+  local -r project="${KUBE_PROJECT:-${PROJECT:-}}"
+  local -r kube_registry="${KUBE_REGISTRY:-gcr.io/${project}}"
+  local -r kube_version="$(get_version)"
+
+  kube::log::status "Pushing fcp image to the registry"
+  tar -xzf ${KUBE_ROOT}/server/federation-server-linux-amd64.tar.gz -C /tmp/
+  gcloud docker -- load -i /tmp/federation/fcp-amd64.tar
+  gcloud docker -- tag "gcr.io/google_containers/fcp-amd64:${kube_version}" "${kube_registry}/fcp-amd64:${kube_version}"
+  gcloud docker -- push "${kube_registry}/fcp-amd64:${kube_version}"
+  gcloud docker -- rmi "gcr.io/google_containers/fcp-amd64:${kube_version}"
+  gcloud docker -- rmi "${kube_registry}/fcp-amd64:${kube_version}"
+  rm -f /tmp/federation/fcp-amd64.tar
+}
+
+push_to_registry
 init
 join_clusters


### PR DESCRIPTION
This PR adds the get-federation.sh scripts equivalent to get-kube.sh. These are needed by the `kubetest` in test-infra to download and run the federation binaries.
This PR also pushes fcp image to registry before bringing up federation.

/assign @irfanurrehman  