### PR TITLE
[auth] add last updated by admission control

### DIFF
--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -74,6 +74,7 @@ filegroup(
         "//pkg/generated/openapi:all-srcs",
         "//pkg/kubefed:all-srcs",
         "//pkg/version:all-srcs",
+        "//plugin/pkg/admission/lastupdatedby:all-srcs",
         "//plugin/pkg/admission/schedulingpolicy:all-srcs",
         "//registry/cluster:all-srcs",
         "//test/e2e:all-srcs",

--- a/cmd/federation-apiserver/app/BUILD
+++ b/cmd/federation-apiserver/app/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//apis/federation/v1beta1:go_default_library",
         "//cmd/federation-apiserver/app/options:go_default_library",
         "//pkg/generated/openapi:go_default_library",
+        "//plugin/pkg/admission/lastupdatedby:go_default_library",
         "//plugin/pkg/admission/schedulingpolicy:go_default_library",
         "//registry/cluster/etcd:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",

--- a/cmd/federation-apiserver/app/plugins.go
+++ b/cmd/federation-apiserver/app/plugins.go
@@ -25,6 +25,7 @@ import (
 
 	// Admission policies
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/federation/plugin/pkg/admission/lastupdatedby"
 	"k8s.io/federation/plugin/pkg/admission/schedulingpolicy"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/admission/deny"
@@ -37,4 +38,5 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	deny.Register(plugins)
 	gc.Register(plugins)
 	schedulingpolicy.Register(plugins)
+	lastupdatedby.Register(plugins)
 }

--- a/plugin/pkg/admission/lastupdatedby/BUILD
+++ b/plugin/pkg/admission/lastupdatedby/BUILD
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    importpath = "k8s.io/federation/plugin/pkg/admission/lastupdatedby",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    importpath = "k8s.io/federation/plugin/pkg/admission/lastupdatedby",
+    library = ":go_default_library",
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/plugin/pkg/admission/lastupdatedby/admission.go
+++ b/plugin/pkg/admission/lastupdatedby/admission.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lastupdatedby
+
+import (
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+)
+
+const (
+	// LastUpdatedByUserAnno is the annotation key used to track the last user who updated the object
+	LastUpdatedByUserAnno = "federation.alpha.kubernetes.io/last-updated-by-user"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("LastUpdatedBy", func(config io.Reader) (admission.Interface, error) {
+		return NewLastUpdatedByAdmit(), nil
+	})
+}
+
+// lastUpdatedByAdmit is an implementation of admission.Interface which injects the user who last updated the object.
+type lastUpdatedByAdmit struct {
+	*admission.Handler
+}
+
+func (a *lastUpdatedByAdmit) Admit(attributes admission.Attributes) error {
+
+	// Ignore all calls to subresources
+	if len(attributes.GetSubresource()) != 0 {
+		return nil
+	}
+
+	// Not an API object
+	accessor, err := meta.Accessor(attributes.GetObject())
+	if err != nil {
+		return nil
+	}
+
+	// Ignore special objects such as SubjectAccessReview, etc.
+	if accessor.GetName() == "" {
+		return nil
+	}
+
+	username := attributes.GetUserInfo().GetName()
+	// Ignore service account calls
+	if strings.HasPrefix(username, serviceaccount.ServiceAccountUsernamePrefix) {
+		return nil
+	}
+
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[LastUpdatedByUserAnno] = username
+	accessor.SetAnnotations(annotations)
+
+	return nil
+}
+
+// NewLastUpdatedByAdmit creates a new last updated by admit admission handler
+func NewLastUpdatedByAdmit() admission.Interface {
+	return &lastUpdatedByAdmit{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}

--- a/plugin/pkg/admission/lastupdatedby/admission_test.go
+++ b/plugin/pkg/admission/lastupdatedby/admission_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lastupdatedby
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	appsv1b2 "k8s.io/api/apps/v1beta2"
+	authnv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestAdmission(t *testing.T) {
+
+	tests := []struct {
+		operation   admission.Operation
+		handles     bool
+		obj         runtime.Object
+		oldObj      runtime.Object
+		resource    schema.GroupVersionResource
+		subResource string
+		userInfo    user.Info
+		expectUser  string
+	}{
+		{
+			admission.Delete,
+			false,
+			nil,
+			nil,
+			schema.GroupVersionResource{},
+			"",
+			nil,
+			"",
+		},
+		{
+			admission.Connect,
+			false,
+			nil,
+			nil,
+			schema.GroupVersionResource{},
+			"",
+			nil,
+			"",
+		},
+		{
+			admission.Create,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			nil,
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"",
+			&user.DefaultInfo{Name: "user1"},
+			"user1",
+		},
+		{
+			admission.Update,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"",
+			&user.DefaultInfo{Name: "user1"},
+			"user1",
+		},
+		{
+			admission.Create,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			nil,
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"status",
+			&user.DefaultInfo{Name: "user1"},
+			"",
+		},
+		{
+			admission.Update,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"status",
+			&user.DefaultInfo{Name: "user1"},
+			"",
+		},
+		{
+			admission.Create,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			nil,
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"",
+			&user.DefaultInfo{Name: "system:serviceaccount:xxx-controller"},
+			"",
+		},
+		{
+			admission.Update,
+			true,
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			&appsv1b2.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}},
+			appsv1b2.SchemeGroupVersion.WithResource("deployments"),
+			"",
+			&user.DefaultInfo{Name: "system:serviceaccount:xxx-controller"},
+			"",
+		},
+		{
+			admission.Create,
+			true,
+			&authnv1.SubjectAccessReview{},
+			nil,
+			authnv1.SchemeGroupVersion.WithResource("subjectaccessreviews"),
+			"",
+			&user.DefaultInfo{Name: "user1"},
+			"",
+		},
+		{
+			admission.Update,
+			true,
+			&authnv1.SubjectAccessReview{},
+			&authnv1.SubjectAccessReview{},
+			authnv1.SchemeGroupVersion.WithResource("subjectaccessreviews"),
+			"",
+			&user.DefaultInfo{Name: "user1"},
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		admi := NewLastUpdatedByAdmit()
+
+		handles := admi.Handles(test.operation)
+		assert.Equal(t, test.handles, handles)
+
+		if !handles {
+			continue
+		}
+
+		accessor, _ := meta.Accessor(test.obj)
+		attrs := admission.NewAttributesRecord(
+			test.obj,
+			test.oldObj,
+			test.obj.GetObjectKind().GroupVersionKind(),
+			accessor.GetNamespace(),
+			accessor.GetName(),
+			test.resource,
+			test.subResource,
+			test.operation,
+			test.userInfo)
+
+		err := admi.Admit(attrs)
+		assert.Nil(t, err)
+		assert.Equal(t, test.expectUser, accessor.GetAnnotations()[LastUpdatedByUserAnno])
+	}
+}


### PR DESCRIPTION
This is part of federation per-user cluster auth (https://github.com/kubernetes/kubernetes/issues/35254)

This PR add a admission control that insert an annotation with the username (service account currently excluded) so later the federation controllers will read the username and find the correct credential accordingly to update objects in the underlying clusters.

@quinton-hoole @deepak-vij 