### PR TITLE
Update Federation OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,12 @@
 reviewers:
-  - colhom
   - csbell
   - irfanurrehman
-  - madhusudancs
   - marun
-  - mwielgus
-  - nikhiljindal
   - quinton-hoole
   - shashidharatd
 approvers:
   - csbell
   - irfanurrehman
-  - madhusudancs
-  - mwielgus
-  - nikhiljindal
+  - marun
   - quinton-hoole
+  - shashidharatd


### PR DESCRIPTION
As discussed during the 11/21/2017 SIG Multicluster meeting,
update OWNERS in the federation repo. Highlights here are pruning
the contributor list to reflect availability of contributors for
reviews. Also, this PR nominates Maru and Shashi as approvers.