### PR TITLE
Integration test verifies replicasets are deleted when namespace is deleted 2

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -29,6 +29,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//vendor/k8s.io/kubernetes/test/integration/framework:go_default_library",
     ],
 )


### PR DESCRIPTION
Accidentally pushed upstream/master to the previous PR #149  which closed it. This includes the squashed commits that @irfanurrehman requested.

For reference:
**What this PR does / why we need it:**
Provides integration tests to test:
- Replicasets created in a namespace are deleted when a namespace is deleted
- Events created in a namespace are deleted when a namespace is deleted

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**
Not aware of any

Special notes for your reviewer:
I believe this is complete for testing replicasets but I am still working on events. I'm unsure how to create a test event to be created in a namespace for this purpose.