### PR TITLE
Improve the tests for Federation API validation

### DIFF
--- a/apis/federation/validation/validation_test.go
+++ b/apis/federation/validation/validation_test.go
@@ -262,6 +262,8 @@ func TestValidateClusterUpdate(t *testing.T) {
 		},
 	}
 	for testName, errorCase := range errorCases {
+		errorCase.old.ObjectMeta.ResourceVersion = "1"
+		errorCase.update.ObjectMeta.ResourceVersion = "1"
 		errs := ValidateClusterUpdate(&errorCase.update, &errorCase.old)
 		if len(errs) == 0 {
 			t.Errorf("expected failure: %s", testName)
@@ -322,6 +324,8 @@ func TestValidateClusterStatusUpdate(t *testing.T) {
 
 	errorCases := map[string]clusterUpdateTest{}
 	for testName, errorCase := range errorCases {
+		errorCase.old.ObjectMeta.ResourceVersion = "1"
+		errorCase.update.ObjectMeta.ResourceVersion = "1"
 		errs := ValidateClusterStatusUpdate(&errorCase.update, &errorCase.old)
 		if len(errs) == 0 {
 			t.Errorf("expected failure: %s", testName)


### PR DESCRIPTION
The parts of the tests that checked for errors will always succeed, because there will always be an error related to `ObjectMeta.ResourceVersion`. Adding the scaffolding from the success cases ensures that that error is not returned, and that the check for some errors is triggered by actual errors.