### PR TITLE
[WIP] Agnostic namespace test for integration/e2e

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -15,14 +15,15 @@
 # Build the fcp image.
 #
 # Usage:
-#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push) 
+#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push)
 # TODO (irfan) figure out a proper release strategy, including version and what all bins
 # VERSION={some_released_version_of_kubernetes}
 
 REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
-FCP_BIN?=_output/dockerized/bin/linux/$(ARCH)/fcp
+FCP_BIN?=_output/local/bin/linux/$(ARCH)/fcp
 VERSION?=1.0
+FCP_IMAGE?=gcr.io/google-containers/fcp-amd64:1.0
 
 # TODO(@irfan) : do we need to rather build our own image from scratch
 BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.7

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "namespace.go",
+        "util.go",
+    ],
+    importpath = "k8s.io/federation/test/common",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//client/clientset_generated/federation_clientset:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+    ],
+)

--- a/test/common/namespace.go
+++ b/test/common/namespace.go
@@ -83,10 +83,10 @@ func CheckNamespaceContentsRemoved(client federationclientset.Interface, l TestL
 		l.Fatalf("Failed to create replicaset %v in namespace %s, err: %s", rs, ns.Name, err)
 	}
 	l.Logf(fmt.Sprintf("Deleting namespace %s", ns.Name))
-	orphanDependents := true
+	orphanDeletion := metav1.DeletePropagationOrphan
 	getter := client.Core().Namespaces().Get
 	deleter := client.Core().Namespaces().Delete
-	err = deleter(ns.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+	err = deleter(ns.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanDeletion})
 	if err != nil {
 		l.Fatalf("Failed to set %s for deletion: %v", ns.Name, err)
 	}

--- a/test/common/namespace.go
+++ b/test/common/namespace.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage/names"
+	federationclientset "k8s.io/federation/client/clientset_generated/federation_clientset"
+)
+
+const (
+	namespacePrefix      = "namespace-test-"
+	replicaSetNamePrefix = "namespace-test-rs-"
+)
+
+func CheckNamespaceContentsRemoved(client federationclientset.Interface, l TestLogger) {
+	//loggers must be initialized in their respective tests
+
+	// Create namespace
+	ns := apiv1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.SimpleNameGenerator.GenerateName(namespacePrefix),
+		},
+	}
+	l.Logf(fmt.Sprintf("Creating namespace %s", ns.Name))
+	_, err := client.Core().Namespaces().Create(&ns)
+	if err != nil {
+		l.Fatalf("Failed to create namespace %s", ns.Name)
+	}
+	l.Logf(fmt.Sprintf("Created namespace %s", ns.Name))
+
+	rsName := names.SimpleNameGenerator.GenerateName(replicaSetNamePrefix)
+	replicaCount := int32(2)
+	rs := &v1beta1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rsName,
+			Namespace: ns.Name,
+		},
+		Spec: v1beta1.ReplicaSetSpec{
+			Replicas: &replicaCount,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "myrs"},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": "myrs"},
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+	l.Logf(fmt.Sprintf("Creating replicaset %s in namespace %s", rsName, ns.Name))
+	_, err = client.Extensions().ReplicaSets(ns.Name).Create(rs)
+	if err != nil {
+		l.Fatalf("Failed to create replicaset %v in namespace %s, err: %s", rs, ns.Name, err)
+	}
+	l.Logf(fmt.Sprintf("Deleting namespace %s", ns.Name))
+	orphanDependents := true
+	getter := client.Core().Namespaces().Get
+	deleter := client.Core().Namespaces().Delete
+	err = deleter(ns.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+	if err != nil {
+		l.Fatalf("Failed to set %s for deletion: %v", ns.Name, err)
+	}
+	waitForNamespaceDeletion(ns.Name, l, getter)
+}
+
+func waitForNamespaceDeletion(namespace string, l TestLogger, getter func(name string, options metav1.GetOptions) (*apiv1.Namespace, error)) {
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		_, err := getter(namespace, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		} else if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		l.Fatalf("Namespaces not deleted: %v", err)
+	}
+}

--- a/test/common/util.go
+++ b/test/common/util.go
@@ -1,0 +1,8 @@
+package common
+
+// TestLogger defines operations common across different types of testing
+type TestLogger interface {
+	Fatalf(format string, args ...interface{})
+	Fatal(msg string)
+	Logf(format string, args ...interface{})
+}

--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//client/clientset_generated/federation_clientset/typed/core/v1:go_default_library",
         "//pkg/federatedtypes:go_default_library",
         "//pkg/federation-controller/util:go_default_library",
+        "//test/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/upgrades:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -23,6 +23,7 @@ import (
 
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/federation/pkg/federatedtypes"
+	"k8s.io/federation/test/common"
 	fedframework "k8s.io/federation/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -31,13 +32,16 @@ var _ = framework.KubeDescribe("Federated types [Feature:Federation][Experimenta
 	var clusterClients []kubeclientset.Interface
 
 	f := fedframework.NewDefaultFederatedFramework("federated-types")
-
 	fedTypes := federatedtypes.FederatedTypes()
 	for name := range fedTypes {
 		fedType := fedTypes[name]
 		Describe(fmt.Sprintf("Federated %q resources", name), func() {
 			It("should be created, read, updated and deleted successfully", func() {
 				fedframework.SkipUnlessFederated(f.ClientSet)
+
+				clientset := f.FederationClientset
+				logger := &fedframework.E2eTestLogger{}
+				common.CheckNamespaceContentsRemoved(clientset, logger)
 
 				// Load clients only if not skipping to avoid doing
 				// unnecessary work.  Assume clients can be shared

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -28,6 +28,26 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+var _ = framework.KubeDescribe("Federated namespace [Feature:Federation][Experimental]", func() {
+	//var clusterClients []kubeclientset.Interface
+	f := fedframework.NewDefaultFederatedFramework("federated-namespace")
+	//	clusterClients = f.GetClusterClients()
+	Describe(fmt.Sprintf("Federated namespace resources"), func() {
+		It("should create, read, update and delete successfully", func() {
+			//		fedframework.SkipUnlessFederated(f.ClientSet)
+			// Load clients only if not skipping to avoid doing
+			// unnecessary work.  Assume clients can be shared
+			// across tests.
+			clientset := f.FederationClientset
+			logger := &fedframework.E2eTestLogger{}
+			common.CheckNamespaceContentsRemoved(clientset, logger)
+			//			if clusterClients == nil {
+			//				clusterClients = f.GetClusterClients()
+			//			}
+		})
+	})
+})
+
 var _ = framework.KubeDescribe("Federated types [Feature:Federation][Experimental] ", func() {
 	var clusterClients []kubeclientset.Interface
 
@@ -38,10 +58,6 @@ var _ = framework.KubeDescribe("Federated types [Feature:Federation][Experimenta
 		Describe(fmt.Sprintf("Federated %q resources", name), func() {
 			It("should be created, read, updated and deleted successfully", func() {
 				fedframework.SkipUnlessFederated(f.ClientSet)
-
-				clientset := f.FederationClientset
-				logger := &fedframework.E2eTestLogger{}
-				common.CheckNamespaceContentsRemoved(clientset, logger)
 
 				// Load clients only if not skipping to avoid doing
 				// unnecessary work.  Assume clients can be shared

--- a/test/e2e/framework/crudtester.go
+++ b/test/e2e/framework/crudtester.go
@@ -25,20 +25,20 @@ import (
 )
 
 // Adapt the methods to log/fail in e2e to the interface expected by CRUDHelper
-type e2eTestLogger struct{}
+type E2eTestLogger struct{}
 
-func (e2eTestLogger) Fatal(msg string) {
+func (E2eTestLogger) Fatal(msg string) {
 	Fail(msg)
 }
 
-func (e2eTestLogger) Fatalf(format string, args ...interface{}) {
+func (E2eTestLogger) Fatalf(format string, args ...interface{}) {
 	framework.Failf(format, args...)
 }
 
-func (e2eTestLogger) Logf(format string, args ...interface{}) {
+func (E2eTestLogger) Logf(format string, args ...interface{}) {
 	framework.Logf(format, args...)
 }
 
 func NewFederatedTypeCRUDTester(adapter federatedtypes.FederatedTypeAdapter, clusterClients []kubeclientset.Interface) *crudtester.FederatedTypeCRUDTester {
-	return crudtester.NewFederatedTypeCRUDTester(&e2eTestLogger{}, adapter, clusterClients, framework.Poll, FederatedDefaultTestTimeout)
+	return crudtester.NewFederatedTypeCRUDTester(&E2eTestLogger{}, adapter, clusterClients, framework.Poll, FederatedDefaultTestTimeout)
 }

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -19,6 +19,7 @@ go_test(
         "//apis/federation/v1beta1:go_default_library",
         "//pkg/federatedtypes:go_default_library",
         "//pkg/federatedtypes/crudtester:go_default_library",
+        "//test/common:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",

--- a/test/integration/framework/crudtester.go
+++ b/test/integration/framework/crudtester.go
@@ -26,19 +26,19 @@ import (
 )
 
 type IntegrationLogger struct {
-	t *testing.T
+	T *testing.T
 }
 
 func (l *IntegrationLogger) Logf(format string, args ...interface{}) {
-	l.t.Logf(format, args...)
+	l.T.Logf(format, args...)
 }
 
 func (l *IntegrationLogger) Fatalf(format string, args ...interface{}) {
-	l.t.Fatalf(format, args...)
+	l.T.Fatalf(format, args...)
 }
 
 func (l *IntegrationLogger) Fatal(msg string) {
-	l.t.Fatal(msg)
+	l.T.Fatal(msg)
 }
 
 func NewFederatedTypeCRUDTester(t *testing.T, adapter federatedtypes.FederatedTypeAdapter, clusterClients []clientset.Interface) *crudtester.FederatedTypeCRUDTester {


### PR DESCRIPTION
**What this PR does / why we need it:**
This is a follow-up test to #159 that:
Allows for integration as well as e2e tests to ensure replicasets created in a namespace are deleted when a namespace is deleted

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**
Not aware of any

Special notes for your reviewer:
namespace tests are failing due to timeout waiting for namespace deletion. Increasing time in "waitForNamespaceDeletion" function (test/common/namespace.go) does not seem to help. 