### PR TITLE
ran ./hack/update-all to address failing verify tests

### DIFF
--- a/client/clientset_generated/federation_clientset/clientset.go
+++ b/client/clientset_generated/federation_clientset/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/doc.go
+++ b/client/clientset_generated/federation_clientset/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/fake/clientset_generated.go
+++ b/client/clientset_generated/federation_clientset/fake/clientset_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/fake/register.go
+++ b/client/clientset_generated/federation_clientset/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/scheme/doc.go
+++ b/client/clientset_generated/federation_clientset/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/scheme/register.go
+++ b/client/clientset_generated/federation_clientset/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/autoscaling_client.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_autoscaling_client.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/generated_expansion.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/batch_client.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_batch_client.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_job.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/generated_expansion.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
+++ b/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/core_client.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/core_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/event.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_configmap.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_core_client.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_core_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_event.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_namespace.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_secret.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_service.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/generated_expansion.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/core/v1/service.go
+++ b/client/clientset_generated/federation_clientset/typed/core/v1/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/extensions_client.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/extensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_extensions_client.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_extensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/generated_expansion.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
+++ b/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/doc.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_cluster.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_federation_client.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_federation_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/federation_client.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/federation_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/clientset_generated/federation_clientset/typed/federation/v1beta1/generated_expansion.go
+++ b/client/clientset_generated/federation_clientset/typed/federation/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -107,7 +107,7 @@ def file_passes(filename, refs, regexs):
             print('File %s is missing the year' % filename, file=verbose_out)
             return False
 
-    # Replace all occurrences of the regex "2017|2016|2015|2014" with "YEAR"
+    # Replace all occurrences of the regex "2018|2017|2016|2015|2014" with "YEAR"
     p = regexs["date"]
     for i, d in enumerate(data):
         (data[i], found) = p.subn('YEAR', d)
@@ -175,8 +175,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017)' )
+    # dates can be 2014, 2015, 2016, 2017 or 2018; company holder names can be anything
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR addresses the failing verify tests performed by the k8s-ci-robot
./hack/verify-codegen.sh seems to be failing due to Boilerplate date set to 2017 instead of 2018.

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**
Fixes: #181  
Fixes verify tests for: #174 #178 #180 

**Special notes for your reviewer:**
Happy New Year~
  
  