### PR TITLE
Reduce length of apiserver credential secret name

### DIFF
--- a/pkg/kubefed/init/init.go
+++ b/pkg/kubefed/init/init.go
@@ -299,9 +299,9 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 		rbacAvailable = false
 	}
 
-	serverName := fmt.Sprintf("%s-%s", i.commonOptions.Name, APIServerNameSuffix)
-	serverCredName := fmt.Sprintf("%s-%s", serverName, CredentialSuffix)
-	cmName := fmt.Sprintf("%s-%s", i.commonOptions.Name, CMNameSuffix)
+	serverName := APIServerNameSuffix
+	serverCredName := fmt.Sprintf("%s-%s", APIServerNameSuffix, CredentialSuffix)
+	cmName := CMNameSuffix
 	cmKubeconfigName := fmt.Sprintf("%s-%s", cmName, KubeconfigNameSuffix)
 
 	var dnsProviderConfigBytes []byte
@@ -332,7 +332,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 
 	fmt.Fprint(cmdOut, "Creating federation control plane objects (credentials, persistent volume claim)...")
 	glog.V(4).Info("Generating TLS certificates and credentials for communicating with the federation API server")
-	credentials, err := generateCredentials(i.commonOptions.FederationSystemNamespace, i.commonOptions.Name, svc.Name, HostClusterLocalDNSZoneName, serverCredName, ips, hostnames, i.options.apiServerEnableHTTPBasicAuth, i.options.apiServerEnableTokenAuth, i.options.dryRun)
+	credentials, err := generateCredentials(i.commonOptions.FederationSystemNamespace, i.commonOptions.Name, svc.Name, HostClusterLocalDNSZoneName, ips, hostnames, i.options.apiServerEnableHTTPBasicAuth, i.options.apiServerEnableTokenAuth, i.options.dryRun)
 	if err != nil {
 		return err
 	}
@@ -591,7 +591,7 @@ func waitForLoadBalancerAddress(cmdOut io.Writer, clientset client.Interface, sv
 	return ips, hostnames, nil
 }
 
-func generateCredentials(svcNamespace, name, svcName, localDNSZoneName, serverCredName string, ips, hostnames []string, enableHTTPBasicAuth, enableTokenAuth, dryRun bool) (*credentials, error) {
+func generateCredentials(svcNamespace, name, svcName, localDNSZoneName string, ips, hostnames []string, enableHTTPBasicAuth, enableTokenAuth, dryRun bool) (*credentials, error) {
 	credentials := credentials{
 		username: AdminCN,
 	}

--- a/pkg/kubefed/init/init_test.go
+++ b/pkg/kubefed/init/init_test.go
@@ -644,10 +644,10 @@ func TestCertsHTTPS(t *testing.T) {
 }
 
 func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, namespaceName, advertiseAddress, lbIp, dnsZoneName, serverImage, etcdImage, dnsProvider, dnsProviderConfig, etcdPersistence, etcdPVCapacity, etcdPVStorageClass, apiserverOverrideArg, cmOverrideArg, tmpDirPath string, apiserverEnableHTTPBasicAuth, apiserverEnableTokenAuth, isRBACAPIAvailable bool, nodeSelectorString string, imagePullPolicy, imagePullSecrets string) (cmdutil.Factory, error) {
-	svcName := federationName + "-apiserver"
+	svcName := "apiserver"
 	svcUrlPrefix := "/api/v1/namespaces/federation-system/services"
-	credSecretName := svcName + "-credentials"
-	cmKubeconfigSecretName := federationName + "-controller-manager-kubeconfig"
+	credSecretName := "apiserver" + "-credentials"
+	cmKubeconfigSecretName := "controller-manager-kubeconfig"
 	pvCap := "10Gi"
 	if etcdPVCapacity != "" {
 		pvCap = etcdPVCapacity
@@ -1036,7 +1036,7 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 	sort.Strings(cmArgs)
 	cmCommand = append(cmCommand, cmArgs...)
 
-	cmName := federationName + "-controller-manager"
+	cmName := "controller-manager"
 	cm := &v1beta1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",


### PR DESCRIPTION
Recent PR builds started failing with error as follows.
```
W0124 04:32:04.366] F0124 04:32:04.212763    1370 helpers.go:119] The Deployment "e2e-f8n-d2c00c37-00ba-11e8-b7d5-0a580a6c0311-0-apiserver" is invalid: 
W0124 04:32:04.366] * spec.template.spec.volumes[0].name: Invalid value: "e2e-f8n-d2c00c37-00ba-11e8-b7d5-0a580a6c0311-0-apiserver-credentials": must be no more than 63 characters
W0124 04:32:04.366] * spec.template.spec.containers[0].volumeMounts[0].name: Not found: "e2e-f8n-d2c00c37-00ba-11e8-b7d5-0a580a6c0311-0-apiserver-credentials"
```
So reduced the name of the apiserver credential secret. the name is still unique as we create it within namespace having unique name.
