### PR TITLE
Update/Correct bazel release bins to be used in release job

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_image", "docker_bundle")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_image", "docker_bundle", "docker_push")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 filegroup(
@@ -27,12 +27,21 @@ docker_image(
     files = ["//cmd/fcp"],
 )
 
+# This is to pack the image in the release tar also.
 docker_bundle(
     name = "fcp-amd64",
     images = {
         "gcr.io/google_containers/fcp-amd64:{STABLE_DOCKER_TAG}": "fcp-image",
     },
     stamp = True,
+)
+
+docker_push(
+    name = "push-fcp-image",
+    image = ":fcp-image",
+    registry = "gcr.io",
+    repository = "$(repository)",
+    tag = "dev",
 )
 
 release_filegroup(

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -74,6 +74,8 @@ pkg_tar(
 pkg_tar(
     name = "federation-client-%s" % PLATFORM_ARCH_STRING,
     extension = "tar.gz",
+    files = [":license-targets"],
+    mode = "0644",
     package_dir = "federation",
     deps = [
         ":_client-bin",

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -83,7 +83,6 @@ pkg_tar(
 pkg_tar(
     name = "_server-bin",
     files = [
-        "//build:client-targets",
         "//build:docker-artifacts",
         "//build:server-targets",
     ],

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -83,11 +83,20 @@ pkg_tar(
 pkg_tar(
     name = "_server-bin",
     files = [
-        "//build:docker-artifacts",
         "//build:server-targets",
     ],
     mode = "0755",
     package_dir = "server/bin",
+    visibility = ["//visibility:private"],
+)
+
+pkg_tar(
+    name = "_server_image-bin",
+    files = [
+        "//build:docker-artifacts",
+    ],
+    mode = "0755",
+    package_dir = "server/bin/image",
     visibility = ["//visibility:private"],
 )
 
@@ -106,6 +115,7 @@ pkg_tar(
     package_dir = "federation",
     deps = [
         ":_server-bin",
+        ":_server_image-bin",
     ],
 )
 


### PR DESCRIPTION
Update the build scripts to generate sane release tars and image tar for release.
