### PR TITLE
Do not delete ExternalIPs

### DIFF
--- a/pkg/federation-controller/service/servicecontroller.go
+++ b/pkg/federation-controller/service/servicecontroller.go
@@ -557,6 +557,8 @@ func getOperationsToPerformOnCluster(informer fedutil.FederatedInformer, cluster
 				}
 			}
 		}
+		// ExternalIPs are not managed by Kubernetes, so retain the same if any while updating
+		desiredService.Spec.ExternalIPs = clusterService.Spec.ExternalIPs
 
 		// Update existing service, if needed.
 		if !Equivalent(desiredService, clusterService) {


### PR DESCRIPTION
**What this PR does / why we need it**: ExternalIPs are not managed by Kubernetes and should not be touched.

This is copy of PR from k8s repo https://github.com/kubernetes/kubernetes/pull/51894
```release-note
NONE
```
/kind bug

cc @quinton-hoole
