### PR TITLE
Fix for non matching api defaults for deployment api

### DIFF
--- a/cmd/federation-apiserver/app/BUILD
+++ b/cmd/federation-apiserver/app/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",


### PR DESCRIPTION
Deployment defaults were not updated in extensions deployment as proposed in https://github.com/kubernetes/kubernetes/pull/34339, but updated in https://github.com/kubernetes/kubernetes/pull/39683 as part of new deployment endpoint.

Recently, after merging https://github.com/kubernetes/kubernetes/pull/58832 and https://github.com/kubernetes/kubernetes/pull/58854, federation builds break for example https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-federation-e2e-gce/3080.

A better mechanism to avoid running into this problem is that federation also updates all the apis that it uses to talk to k8s and to store in its registry. This will eventually happen and while we chalk out a plan for that, the current fix is to use an api type with same defaulting values in federation to store the deployment object in federation registry.