### PR TITLE
 Fix broken DNS CNAME chain for cross-cluster service discovery

### DIFF
--- a/pkg/federation-controller/service/ingress/ingress.go
+++ b/pkg/federation-controller/service/ingress/ingress.go
@@ -89,7 +89,7 @@ func (ingress *FederatedServiceIngress) AddClusterLoadBalancerIngresses(cluster 
 // AddEndpoints adds one or more endpoints to the federated service ingress.
 // Endpoints are the federated cluster's loadbalancer ip/hostname for the service
 func (ingress *FederatedServiceIngress) AddEndpoints(cluster string, endpoints []string) *FederatedServiceIngress {
-	lbIngress := []v1.LoadBalancerIngress{}
+	var lbIngress []v1.LoadBalancerIngress
 	for _, endpoint := range endpoints {
 		if net.ParseIP(endpoint) == nil {
 			lbIngress = append(lbIngress, v1.LoadBalancerIngress{Hostname: endpoint})

--- a/pkg/federation-controller/service/servicecontroller.go
+++ b/pkg/federation-controller/service/servicecontroller.go
@@ -481,16 +481,16 @@ func (s *ServiceController) reconcileService(key string) reconciliationStatus {
 			if err != nil {
 				return statusRecoverableError
 			}
+			clusterIngress := fedapi.ClusterServiceIngress{
+				Cluster: cluster.Name,
+			}
 			// if there are no endpoints created for the service then the loadbalancer ingress
 			// is not reachable, so do not consider such loadbalancer ingresses for federated
 			// service ingresses
 			if len(endpoints) > 0 {
-				clusterIngress := fedapi.ClusterServiceIngress{
-					Cluster: cluster.Name,
-					Items:   lbStatus.Ingress,
-				}
-				newServiceIngress.Items = append(newServiceIngress.Items, clusterIngress)
+				clusterIngress.Items = lbStatus.Ingress
 			}
+			newServiceIngress.Items = append(newServiceIngress.Items, clusterIngress)
 		}
 	}
 

--- a/pkg/federation-controller/service/servicecontroller_test.go
+++ b/pkg/federation-controller/service/servicecontroller_test.go
@@ -191,6 +191,7 @@ func TestServiceController(t *testing.T) {
 
 	glog.Infof("Test federation service is updated when cluster1 endpoint for the service is deleted")
 	desiredIngressAnnotation = ingress.NewFederatedServiceIngress().
+		AddEndpoints("cluster1", []string{}).
 		AddEndpoints("cluster2", []string{lbIngress2}).
 		String()
 	desiredService = &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ingress.FederatedServiceIngressAnnotation: desiredIngressAnnotation}}}

--- a/pkg/kubefed/init/init.go
+++ b/pkg/kubefed/init/init.go
@@ -1008,7 +1008,7 @@ func createControllerManager(clientset client.Interface, namespace, name, svcNam
 		dep = addDNSProviderConfig(dep, dnsProviderSecret.Name)
 		if dnsProvider == util.FedDNSProviderCoreDNS {
 			var err error
-			dep, err = addCoreDNSServerAnnotation(dep, dnsZoneName, dnsProviderConfig)
+			dep, err = addCoreDNSServerAnnotation(dep, strings.TrimRight(dnsZoneName, "."), dnsProviderConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kubefed/init/init_test.go
+++ b/pkg/kubefed/init/init_test.go
@@ -1113,7 +1113,7 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 	if dnsProviderConfig != "" {
 		cm = addDNSProviderConfigTest(cm, cmDNSProviderSecret.Name)
 		if dnsProvider == util.FedDNSProviderCoreDNS {
-			cm, err = addCoreDNSServerAnnotationTest(cm, dnsZoneName, dnsProviderConfig)
+			cm, err = addCoreDNSServerAnnotationTest(cm, strings.TrimRight(dnsZoneName, "."), dnsProviderConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kubefed/join.go
+++ b/pkg/kubefed/join.go
@@ -394,6 +394,7 @@ func createConfigMap(hostClientSet internalclientset.Interface, config util.Admi
 		// For some reason the configMap exists but this data is empty
 		existingConfigMap.Data[util.FedDomainMapKey] = cmDep.Annotations[util.FedDomainMapKey]
 	}
+	existingConfigMap = populateStubDomainsIfRequired(existingConfigMap, cmDep.Annotations)
 
 	if dryRun {
 		return existingConfigMap, nil
@@ -503,6 +504,8 @@ func populateStubDomainsIfRequired(configMap *api.ConfigMap, annotations map[str
 	if dnsProvider != util.FedDNSProviderCoreDNS || dnsZoneName == "" || nameServer == "" {
 		return configMap
 	}
+
+	glog.V(2).Info("Added stubDomains to kube-dns configmap, %s:[%s]", dnsZoneName, nameServer)
 	configMap.Data[util.KubeDnsStubDomains] = fmt.Sprintf(`{"%s":["%s"]}`, dnsZoneName, nameServer)
 	return configMap
 }


### PR DESCRIPTION
Partly addresses the issue in https://github.com/kubernetes/federation/issues/175

CNAME records were missed for the federated cluster without healthy service shards. This pr fixes the missing CNAME records issue.

/cc @kubernetes/sig-multicluster-bugs 
/assign @irfanurrehman 