### PR TITLE
Fix deepcopy invocation of federated ingress spec to cluster ingress …

### DIFF
--- a/pkg/federation-controller/ingress/BUILD
+++ b/pkg/federation-controller/ingress/BUILD
@@ -55,6 +55,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/pkg/federation-controller/ingress/ingress_controller.go
+++ b/pkg/federation-controller/ingress/ingress_controller.go
@@ -738,7 +738,7 @@ func (ic *IngressController) reconcileIngress(ingress types.NamespacedName) {
 		}
 		desiredIngress := &extensionsv1beta1.Ingress{}
 		desiredIngress.ObjectMeta = *baseIngress.ObjectMeta.DeepCopy()
-		desiredIngress.Spec = *desiredIngress.Spec.DeepCopy()
+		desiredIngress.Spec = *baseIngress.Spec.DeepCopy()
 
 		glog.V(4).Infof("Desired Ingress: %v", desiredIngress)
 

--- a/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
@@ -121,6 +122,12 @@ func TestIngressController(t *testing.T) {
 			SelfLink:  "/api/v1/namespaces/mynamespace/ingress/test-ingress",
 			Annotations: map[string]string{
 				firstClusterAnnotation: cluster1.Name,
+			},
+		},
+		Spec: extensionsv1beta1.IngressSpec{
+			Backend: &extensionsv1beta1.IngressBackend{
+				ServiceName: "hello-server",
+				ServicePort: intstr.FromString("8080"),
 			},
 		},
 		Status: extensionsv1beta1.IngressStatus{


### PR DESCRIPTION
…spec

Fixes: https://github.com/kubernetes/federation/issues/242

Surprising that this bug existed for so long time. 
Have updated the testcase to cover this scenario.

/cc @quinton-hoole @kubernetes/sig-multicluster-bugs 
/assign @irfanurrehman 