### PR TITLE
Fix comparison of golang versions

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -280,7 +280,7 @@ EOF
   local go_version
   go_version=($(go version))
   local minimum_go_version
-  minimum_go_version=go1.9.1
+  minimum_go_version=go1.8.3
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -280,8 +280,8 @@ EOF
   local go_version
   go_version=($(go version))
   local minimum_go_version
-  minimum_go_version=go1.8.3
-  if [[ "${go_version[2]}" < "${minimum_go_version}" && "${go_version[2]}" != "devel" ]]; then
+  minimum_go_version=go1.9.1
+  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.
 Kubernetes requires ${minimum_go_version} or greater.


### PR DESCRIPTION
Change hack/lib/golang.sh to compare golang
version properly with "sort -s -t. -k 1,1 -k 2,2n -k 3,3n",
which sorts key by key and not as strings.