### PR TITLE
Alternative path (then default usage of RBAC) for kubefed cluster access

### DIFF
--- a/pkg/kubefed/init/init_test.go
+++ b/pkg/kubefed/init/init_test.go
@@ -297,7 +297,7 @@ func TestInitFederation(t *testing.T) {
 		cmd := NewCmdInit(buf, adminConfig, "serverImage", defaultEtcdImage)
 
 		cmd.Flags().Set("kubeconfig", tc.kubeconfigExplicit)
-		cmd.Flags().Set("use-credentials-kubeconfig", tc.kubeconfigForCredentials)
+		cmd.Flags().Set("credentials-kubeconfig", tc.kubeconfigForCredentials)
 		cmd.Flags().Set("host-cluster-context", "substrate")
 		cmd.Flags().Set("dns-zone-name", tc.dnsZoneName)
 		cmd.Flags().Set("image", tc.serverImage)

--- a/pkg/kubefed/util/util.go
+++ b/pkg/kubefed/util/util.go
@@ -141,12 +141,16 @@ type SubcommandOptions struct {
 	Host                      string
 	FederationSystemNamespace string
 	Kubeconfig                string
+	CredentialsKubeconfig     string
 }
 
 func (o *SubcommandOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 	flags.StringVar(&o.Host, "host-cluster-context", "", "Host cluster context")
 	flags.StringVar(&o.FederationSystemNamespace, "federation-system-namespace", DefaultFederationSystemNamespace, "Namespace in the host cluster where the federation system components are installed")
+	flags.StringVar(&o.CredentialsKubeconfig, "use-credentials-kubeconfig", "", "Kubeconfig file path on local file system, which should be used to authenticate with base cluster (instead of the default kubeconfig)."+
+		"This can be used to override the RBAC based authentication while initialising the federation control plane, even when the base cluster exposes the RBAC API.")
+
 }
 
 func (o *SubcommandOptions) SetName(cmd *cobra.Command, args []string) error {

--- a/pkg/kubefed/util/util.go
+++ b/pkg/kubefed/util/util.go
@@ -148,8 +148,8 @@ func (o *SubcommandOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 	flags.StringVar(&o.Host, "host-cluster-context", "", "Host cluster context")
 	flags.StringVar(&o.FederationSystemNamespace, "federation-system-namespace", DefaultFederationSystemNamespace, "Namespace in the host cluster where the federation system components are installed")
-	flags.StringVar(&o.CredentialsKubeconfig, "use-credentials-kubeconfig", "", "Kubeconfig file path on local file system, which should be used to authenticate with base cluster (instead of the default kubeconfig)."+
-		"This can be used to override the RBAC based authentication while initialising the federation control plane, even when the base cluster exposes the RBAC API.")
+	flags.StringVar(&o.CredentialsKubeconfig, "credentials-kubeconfig", "", "Kubeconfig file path on local file system, which should be used to authenticate with host cluster or the joining cluster (instead of the default kubeconfig)."+
+		"This can be used to override the RBAC based authentication while initialising the federation control plane or joining a cluster to one, even when the cluster exposes the RBAC API.")
 
 }
 


### PR DESCRIPTION
Implements functionality as discussed in https://github.com/kubernetes/federation/issues/210.
kubefed gets a new flag `--use-credentials-kubeconfig`. 
/assign @shashidharatd 