### PR TITLE
Enable test to check cross cluster federated service discovery

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -253,7 +253,7 @@ var _ = framework.KubeDescribe("Federated Services [Feature:Federation]", func()
 
 				})
 
-				PIt("should be able to discover a non-local federated service", func() {
+				It("should be able to discover a non-local federated service", func() {
 					fedframework.SkipUnlessFederated(f.ClientSet)
 
 					nsName := f.FederationNamespace.Name


### PR DESCRIPTION
Enable to check the flakiness of this test in current setup.