### PR TITLE
Remove duplicated words

### DIFF
--- a/pkg/dnsprovider/providers/aws/route53/interface.go
+++ b/pkg/dnsprovider/providers/aws/route53/interface.go
@@ -29,7 +29,7 @@ type Interface struct {
 }
 
 // New builds an Interface, with a specified Route53API implementation.
-// This is useful for testing purposes, but also if we want an instance with with custom AWS options.
+// This is useful for testing purposes, but also if we want an instance with custom AWS options.
 func New(service stubs.Route53API) *Interface {
 	return &Interface{service}
 }

--- a/pkg/federation-controller/cluster/clustercontroller_test.go
+++ b/pkg/federation-controller/cluster/clustercontroller_test.go
@@ -66,7 +66,7 @@ func newClusterList(cluster *federationv1beta1.Cluster) *federationv1beta1.Clust
 }
 
 // init a fake http handler, simulate a federation apiserver, response the "DELETE" "PUT" "GET" "UPDATE"
-// when "canBeGotten" is false, means that user can not get the cluster cluster from apiserver
+// when "canBeGotten" is false, means that user can not get the cluster from apiserver
 func createHttptestFakeHandlerForFederation(clusterList *federationv1beta1.ClusterList, canBeGotten bool) *http.HandlerFunc {
 	fakeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		clusterListString, _ := json.Marshal(*clusterList)

--- a/test/k8s/e2e/framework/framework.go
+++ b/test/k8s/e2e/framework/framework.go
@@ -203,7 +203,7 @@ func (f *Framework) AfterEach() {
 
 	// Print events if the test failed.
 	if CurrentGinkgoTestDescription().Failed && TestContext.DumpLogsOnFailure {
-		// Pass both unversioned client and and versioned clientset, till we have removed all uses of the unversioned client.
+		// Pass both unversioned client and versioned clientset, till we have removed all uses of the unversioned client.
 		if !f.SkipNamespaceCreation {
 			DumpAllNamespaceInfo(f.ClientSet, f.Namespace.Name)
 		}


### PR DESCRIPTION
Remove duplicated words in below files to make it more clearly:
1. pkg/dnsprovider/providers/aws/route53/interface.go
2. pkg/federation-controller/cluster/clustercontroller_test.go
3. test/k8s/e2e/framework/framework.go