### PR TITLE
Fix typos issues in master-helper.sh

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -81,7 +81,7 @@ docker-machine create \
 # Set up local docker to talk to that machine
 eval $(docker-machine env ${KUBE_BUILD_VM})
 
-# Pin down the port that rsync will be exposed on on the remote machine
+# Pin down the port that rsync will be exposed on the remote machine
 export KUBE_RSYNC_PORT=8730
 
 # forward local 8730 to that machine so that rsync works

--- a/build/README.md
+++ b/build/README.md
@@ -81,7 +81,7 @@ docker-machine create \
 # Set up local docker to talk to that machine
 eval $(docker-machine env ${KUBE_BUILD_VM})
 
-# Pin down the port that rsync will be exposed on the remote machine
+# Pin down the rsync port which will be exposed on the remote machine
 export KUBE_RSYNC_PORT=8730
 
 # forward local 8730 to that machine so that rsync works

--- a/cluster/gce/container-linux/master-helper.sh
+++ b/cluster/gce/container-linux/master-helper.sh
@@ -22,7 +22,7 @@ source "${KUBE_ROOT}/cluster/gce/container-linux/helper.sh"
 # address for the master. (In the case of upgrade/repair, we re-use
 # the same IP.)
 #
-# It requires a whole slew of assumed variables, partially due to to
+# It requires a whole slew of assumed variables, partially due to
 # the call to write-master-env. Listing them would be rather
 # futile. Instead, we list the required calls to ensure any additional
 #


### PR DESCRIPTION
Fix typos issues in below files:
1. build/README.md
2. cluster/gce/container-linux/master-helper.sh